### PR TITLE
CLIC-84-PHP-8.X-PHP-Parser

### DIFF
--- a/bin/fullParse.php
+++ b/bin/fullParse.php
@@ -208,7 +208,7 @@ function bamSwitch(&$obj) { //should i go through arrays and bam items, some thi
         case "Scalar_LNumber":
             $numberInterval = Down(Interval($obj->attributes["startFilePos"],
                     $obj->attributes["endFilePos"] + 1));
-            $parentInterval = property_exists($obj, "parentAttributes") ? Down(Interval($obj->parentAttributes["startFilePos"], $obj->parentAttributes["endFilePos"] + 1)) : NULL;
+            $parentInterval = isset($obj->parentAttributes) ? Down(Interval($obj->parentAttributes["startFilePos"], $obj->parentAttributes["endFilePos"] + 1)) : NULL;
             $obj->value = Custom_ScalarLNumber([
               "number" => $numberInterval,
              "parentString" => $parentInterval,
@@ -217,7 +217,7 @@ function bamSwitch(&$obj) { //should i go through arrays and bam items, some thi
         case "Scalar_DNumber":
             $numberInterval = Down(Interval($obj->attributes["startFilePos"],
                     $obj->attributes["endFilePos"] + 1));
-            $parentInterval = property_exists($obj, "parentAttributes") ? Down(Interval($obj->parentAttributes["startFilePos"], $obj->parentAttributes["endFilePos"] + 1)) : NULL;
+            $parentInterval = isset($obj->parentAttributes) ? Down(Interval($obj->parentAttributes["startFilePos"], $obj->parentAttributes["endFilePos"] + 1)) : NULL;
             $obj->value = Custom_Scalar_DNumber([
               "number" => $numberInterval,
               "parentString" => $parentInterval,

--- a/lib/PhpParser/NodeAbstract.php
+++ b/lib/PhpParser/NodeAbstract.php
@@ -3,7 +3,35 @@
 namespace PhpParser;
 
 abstract class NodeAbstract implements Node, \JsonSerializable
-{
+{   
+    // Used by PHP-Parser-1
+    public $attributes;
+
+    // Used by fullParse.php
+    public $parent;
+    public $parentAttributes;
+    public $source;
+
+    // Used by bam.php
+    public $allowAnyref;
+    public $classScope;
+    public $classStaticScope;
+    public $ctor;
+    public $duplicateValue;
+    public $expr;
+    public $fileName;
+    public $isGenerator;
+    public $isset_context;
+    public $namespace;
+    public $no_autoload;
+    public $remove_byref;
+    public $staticVars;
+    public $this;
+    public $use;
+    public $useConstant;
+    public $useFunction;
+    public $uses_computed;
+
     /**
      * Creates a Node.
      *


### PR DESCRIPTION
Add support for PHP 8.X. Includes declaration of previously dynamic properties and necessary adjustments to fullParse.